### PR TITLE
Make title screen and book display correctly

### DIFF
--- a/BookPatch.cs
+++ b/BookPatch.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+
+namespace ResolutionFix
+{
+    [HarmonyPatch]
+    public class BookPatch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Book), "OnEnable")]
+        public static void Prefix_OnEnable()
+        {
+            Plugin.IsHighRes = false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Book), "OnDisable")]
+        public static void Prefix_OnDisable()
+        {
+            Plugin.IsHighRes = true;
+        }
+    }
+}

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -9,6 +9,8 @@ namespace ResolutionFix
     [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
     public class Plugin : BaseUnityPlugin
     {
+        public static bool IsHighRes { get; set; } = true;
+
         private void Awake()
         {
             // Plugin startup logic
@@ -17,7 +19,7 @@ namespace ResolutionFix
             Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly());
 
             SceneManager.sceneLoaded += sceneManager_sceneLoaded;
-            //SceneManager.activeSceneChanged += sceneManager_activeSceneChanged;
+            SceneManager.activeSceneChanged += sceneManager_activeSceneChanged;
         }
 
         private void sceneManager_sceneLoaded(Scene scene, LoadSceneMode mode)
@@ -26,10 +28,36 @@ namespace ResolutionFix
             fixScene();
         }
 
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.F9))
+            {
+                IsHighRes = !IsHighRes;
+            }
+            if (Input.GetKeyDown(KeyCode.Tab)) // hack so the book displays fullscreen
+            {
+                IsHighRes = !IsHighRes;
+            }
+        }
+
+        private void sceneManager_activeSceneChanged(Scene scene1, Scene scene2)
+        {
+            var sceneName = scene2.name;
+            if (sceneName == "Book" || sceneName == "Title" || sceneName == "Pause")
+            {
+                IsHighRes = false;
+            }
+            else
+            {
+                IsHighRes = true;
+            }
+
+        }
+
         private void fixScene()
         {
             var scene = SceneManager.GetActiveScene();
-            
+
             foreach (var root in scene.GetRootGameObjects())
             {
                 /*

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -22,22 +22,19 @@ namespace ResolutionFix
             SceneManager.activeSceneChanged += sceneManager_activeSceneChanged;
         }
 
-        private void sceneManager_sceneLoaded(Scene scene, LoadSceneMode mode)
-        {
-            Logger.LogInfo($"   SCENE LOADED: " + scene.name);
-            fixScene();
-        }
-
         private void Update()
         {
             if (Input.GetKeyDown(KeyCode.F9))
             {
                 IsHighRes = !IsHighRes;
             }
-            if (Input.GetKeyDown(KeyCode.Tab)) // hack so the book displays fullscreen
-            {
-                IsHighRes = !IsHighRes;
-            }
+
+        }
+
+        private void sceneManager_sceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            Logger.LogInfo($"   SCENE LOADED: " + scene.name);
+            fixScene();
         }
 
         private void sceneManager_activeSceneChanged(Scene scene1, Scene scene2)

--- a/ResolutionPatch.cs
+++ b/ResolutionPatch.cs
@@ -10,7 +10,10 @@ namespace ResolutionFix
         [HarmonyPatch(typeof(Resolution), nameof(Resolution.bufferW), MethodType.Getter)]
         public static bool Prefix_BufferW_Get(ref int __result)
         {
-            __result = Screen.width;
+            if (Plugin.IsHighRes)
+                __result = Screen.width;
+            else
+                __result = 800;
             return false;
         }
 
@@ -18,7 +21,10 @@ namespace ResolutionFix
         [HarmonyPatch(typeof(Resolution), nameof(Resolution.bufferH), MethodType.Getter)]
         public static bool Prefix_BufferH_Get(ref int __result)
         {
-            __result = Screen.height;
+            if (Plugin.IsHighRes)
+                __result = Screen.height;
+            else
+                __result = 450;
             return false;
         }
     }

--- a/SettingsMenuPatch.cs
+++ b/SettingsMenuPatch.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+
+namespace ResolutionFix
+{
+    [HarmonyPatch]
+    public class SettingsMenuPatch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Book), "OnEnable")]
+        public static void Prefix_OnEnable()
+        {
+            Plugin.IsHighRes = false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Book), "OnDisable")]
+        public static void Prefix_OnDisable()
+        {
+            Plugin.IsHighRes = true;
+        }
+    }
+}


### PR DESCRIPTION
This is a hacky way around the title screen not displaying correctly and to fix the book showing very small.

* Added a global property so high-res can be turned on/off.
* Turn off high-res on the Title scene showing.
* Turn on high-res when the Ship scene is loaded.
* Patch the book onEnable to turn-off high res when book is shown
* User option to toggle with the F9 key